### PR TITLE
open folds when appropriate

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -252,6 +252,11 @@ function! clever_f#find(map, char_num)
         endif
     endif
 
+    " open folds if necessary to maintain cursor visibility
+    if foldlevel('.') > 0
+        call feedkeys('zv')
+    endif
+
     let s:moved_forward = moves_forward
     let s:previous_pos[mode] = next_pos
     let s:first_move[mode] = 0


### PR DESCRIPTION
Virtually all of the builtin motions (to include "dumb" `f`) open as many folds
as necessary to keep the target visible. This patch makes clever-f follow suit.
