### PR TITLE
Ignore help tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+doc/tags


### PR DESCRIPTION
This is useful so that, if you do a git clone to install this plugin, git doesn't think the repo has been modified after you run :helptags.