### PR TITLE
Cancel searching when put <esc>

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -137,6 +137,9 @@ function! clever_f#find_with(map)
             let s:previous_map[mode] = a:map
             let s:first_move[mode] = 1
             let cn = s:getchar()
+            if cn == char2nr("\<Esc>")
+              return "\<Esc>"
+            endif
             if index(map(deepcopy(g:clever_f_repeat_last_char_inputs), 'char2nr(v:val)'), cn) == -1
                 let s:previous_char_num[mode] = cn
             else

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -138,7 +138,7 @@ function! clever_f#find_with(map)
             let s:first_move[mode] = 1
             let cn = s:getchar()
             if cn == char2nr("\<Esc>")
-              return "\<Esc>"
+                return "\<Esc>"
             endif
             if index(map(deepcopy(g:clever_f_repeat_last_char_inputs), 'char2nr(v:val)'), cn) == -1
                 let s:previous_char_num[mode] = cn


### PR DESCRIPTION
Goal
----


Cancel searching when puts `<Esc>` key.



Current behavior 
-----

- Puts `f<Esc>`, do nothing.
- Puts `df<Esc>`, delete one character.

For example, 



```
hoge fuga
```

Open the above text, and cursor moves to head.
Type `df<Esc>`, the text changes to the following.

```
oge fuga
```

I think it's confusing.


Proposal behavior
------

- Puts `f<Esc>`, do nothing
- Puts `df<Esc>`, do nothing



Reference behavior
----

When Vim is without the plugin(`vim -u NONE`), behavior is same as `Proposal behavior`.

So, I think the proposal behavior is better than before.
