### PR TITLE
Fix `t` and `T` with migemo

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -336,9 +336,9 @@ function! s:generate_pattern(map, char_num)
     endif
 
     if a:map ==# 't'
-        let regex = '\_.\ze' . regex
+        let regex = '\_.\ze\%(' . regex . '\)'
     elseif a:map ==# 'T'
-        let regex = regex . '\@<=\_.'
+        let regex = '\%(' . regex . '\)\@<=\_.'
     endif
 
     if !should_use_migemo


### PR DESCRIPTION
When g:clever_f_use_migemo is TRUE, the searching pattern would be as
follows(with searching W):

    \%(...migemo-pattern...)\&\%(W\|\A\)

When using t, the pattern would be as follows:

    \_.\ze\%(...migemo-pattern...)\&\%(W\|\A\)

This pattern includes \& .  This does not work as intended.

It should be:

    \_.\ze\%(\%(...migemo-pattern...)\&\%(W\|\A\)\)

P.S.
Sorry, test is missing 🙇 