### PR TITLE
Fix 't' and 'T' searching '\'

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -338,6 +338,8 @@ function! s:generate_pattern(map, char_num) abort
         let regex = s:migemo_dicts[&l:encoding][regex] . '\&\%(' . char . '\|\A\)'
     elseif stridx(g:clever_f_chars_match_any_signs, char) != -1
         let regex = '\[!"#$%&''()=~|\-^\\@`[\]{};:+*<>,.?_/]'
+    elseif char ==# '\'
+        let regex = '\\'
     endif
 
     let is_exclusive_visual = &selection ==# 'exclusive' && mode(1) ==? 'v'

--- a/test/t/clever_f_spec.vim
+++ b/test/t/clever_f_spec.vim
@@ -664,6 +664,34 @@ describe 'Special characters'
     end
 end
 
+describe 'Backslash'
+
+    before
+        new
+        call clever_f#reset()
+        call AddLine('poge\huga\hiyo\poyo')
+        normal! gg0
+    end
+
+    after
+        close!
+    end
+
+    it 'does not cause any search errors'
+        normal f\
+        Expect col('.') == 5
+        normal! $
+        normal F\
+        Expect col('.') == 15
+        normal! gg0
+        normal t\
+        Expect col('.') == 4
+        normal! $
+        normal T\
+        Expect col('.') == 16
+    end
+end
+
 describe '<Esc>'
 
     before


### PR DESCRIPTION
## Problem

`t\` and `T\` (searching backslash) cause a search error.

## Repro steps

vimrc:

```vim
set rtp+=/path/to/clever-f.vim
```

`vim -Nu vimrc`

```vim
:normal! ia\a
:normal! gg0
:normal t\
```

```
Error detected while processing function clever_f#find_with[58]..<SNR>23_mark_char_in_current_line:
line    2:
E53: Unmatched \%(
E53: Unmatched \%(
E475: Invalid argument: \%1l\C\V\_.\ze\%(\\)
```

Invalid regex pattern is generated.