### PR TITLE
[RFC] Add feature to highlight characters to which the cursor can be moved directly

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -121,11 +121,13 @@ function! s:mark_direct(forward, count) abort
     let matches = []
     for i in range(i_start, i_end, i_step)
         let ch = line[i]
+        " only matches to ASCII
+        if ch !~ '^[\x00-\x7F]$' | continue | endif
         let ch_lower = tolower(ch)
-        if ch !~ '^\a$' | continue | endif
 
         let char_count[ch] = get(char_count, ch, 0) + 1
-        if g:clever_f_smart_case && ch =~# '\L'
+        if g:clever_f_smart_case && ch =~# '\u'
+            " uppercase characters are doubly counted
             let char_count[ch_lower] = get(char_count, ch_lower, 0) + 1
         endif
 

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -139,6 +139,10 @@ function! s:mark_direct(forward, count) abort
     endfor
     return matches
 endfunction
+
+" introduce public function for test
+function! clever_f#_mark_direct(forward, count) abort
+    return s:mark_direct(a:forward, a:count)
 endfunction
 
 function! s:mark_char_in_current_line(map, char) abort

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -108,8 +108,8 @@ function! s:mark_direct(forward, count) abort
     let l = line('.')
 
     if (a:forward && c_start+1 > len(line)-1) ||
-        \(!a:forward && c_end + 1 < 0)
-        return
+        \(!a:forward && c_end+1 < 0)
+        return []
     endif
 
     if g:clever_f_ignore_case
@@ -120,8 +120,8 @@ function! s:mark_direct(forward, count) abort
         \             : range(c_end, 0, -1)
     let d = {}
     let ms = []
-    for c in r
-        let ch = line[c]
+    for i in r
+        let ch = line[i]
         let ch_lower = tolower(ch)
         " TODO: migemo suport
         if ch !~ '^\a$' | continue | endif
@@ -132,7 +132,7 @@ function! s:mark_direct(forward, count) abort
         if d[ch] == a:count || (g:clever_f_smart_case && d[ch_lower] == a:count)
             " NOTE: should not use `matchaddpos(group, [...position])`,
             " because the maximum number of position is 8
-            let m = matchaddpos('CleverFDirect', [[l, c+1]])
+            let m = matchaddpos('CleverFDirect', [[l, i+1]])
             call add(ms, m)
         endif
     endfor

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -123,7 +123,6 @@ function! s:mark_direct(forward, count) abort
     for i in r
         let ch = line[i]
         let ch_lower = tolower(ch)
-        " TODO: migemo suport
         if ch !~ '^\a$' | continue | endif
         let d[ch] = get(d, ch, 0)+1
         if g:clever_f_smart_case && ch =~# '\L'

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -112,16 +112,24 @@ function! s:mark_direct(forward, count) abort
         return
     endif
 
+    if g:clever_f_ignore_case
+        let line = tolower(line)
+    endif
+
     let r = a:forward ? range(c_start, len(line)-1)
         \             : range(c_end, 0, -1)
     let d = {}
     let ms = []
     for c in r
         let ch = line[c]
+        let ch_lower = tolower(ch)
         " TODO: migemo suport
-        " TODO: `g:clever_f_smart_case` and `g:clever_f_ignore_case` support
+        if ch !~ '^\a$' | continue | endif
         let d[ch] = get(d, ch, 0)+1
-        if ch =~ '[\x01-\x7E]' && d[ch] == a:count
+        if g:clever_f_smart_case && ch =~# '\L'
+            let d[ch_lower] = get(d, ch_lower, 0)+1
+        endif
+        if d[ch] == a:count || (g:clever_f_smart_case && d[ch_lower] == a:count)
             " NOTE: should not use `matchaddpos(group, [...position])`,
             " because the maximum number of position is 8
             let m = matchaddpos('CleverFDirect', [[l, c+1]])

--- a/doc/clever_f.txt
+++ b/doc/clever_f.txt
@@ -207,6 +207,27 @@ g:clever_f_repeat_last_char_inputs          *g:clever_f_repeat_last_char_inputs*
 >
     let g:clever_f_repeat_last_char_inputs = ["\<CR>", "\<Tab>"]
 <
+g:clever_f_mark_direct                                  *g:clever_f_mark_direct*
+
+    If the value is equivalent to 1, characters to which the cursor can be
+    moved directly are highlighted until you input a character.  Highlighting
+    is enabled in normal and visual mode.
+    The default value is 0.
+
+g:clever_f_mark_direct_color                      *g:clever_f_mark_direct_color*
+
+    If |g:clever_f_mark_direct| is enabled, |clever-f| highlights characters
+    using the highlight group which |g:clever_f_mark_direct_color| specifies.
+    If you want to change the highlight group |clever-f| uses, set
+    your favorite highlight group to this variable.
+    The default value is "CleverFDefaultLabel", which makes characters red and
+    bold.  If you want to make an original label highlight, define your own
+    highlight group.(See |:highlight|)
+
+    Note:
+    |g:clever_f_mark_direct_color| must be set before |clever-f| is loaded.
+    (e.g. in your |vimrc|)
+
 
 ==============================================================================
 SPECIAL THANKS                                     *clever-f.vim-special-thanks*

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -713,6 +713,23 @@ Describe <Esc>
         normal Th
         Assert Equals(col('.'), 7)
     End
+
+    Context with g:clever_f_mark_direct
+        Before
+            let g:clever_f_mark_direct = 1
+            highlight link CleverFDirect CleverFDefaultLabel
+        End
+
+        After
+            let g:clever_f_mark_direct = 0
+        End
+
+        It should remove target highlights
+            normal! gg0
+            execute 'normal' "f\<Esc>"
+            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
+        End
+    End
 End
 
 Describe g:clever_f_smart_case
@@ -1095,13 +1112,13 @@ Describe selection=exclusive
     End
 End
 
-Describe g:clever_f_mark_direct
+Describe clever_f#_mark_direct()
     Before
         new
-        let g:clever_f_mark_direct = 1
         call clever_f#reset()
         highlight link CleverFDirect CleverFDefaultLabel
-        call AddLine('pOge huga Hiyo poyo')
+        call AddLine('ビムかわいいよzビムx')
+        call AddLine('pOge huga Hiyo pOyo')
         let old_across_no_line = g:clever_f_across_no_line
         let g:clever_f_across_no_line = 0
     End
@@ -1112,10 +1129,115 @@ Describe g:clever_f_mark_direct
         let g:clever_f_across_no_line = old_across_no_line
     End
 
-    It should highlight target characters automatically
+    It should highlight characters to which the cursor can be moved directly
         normal! gg0
-        normal f
-        Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 11)
+        " #: cursor position, _: highlighted char
+        "
+        "     pOge huga Hiyo pOyo
+        " len(#______ _ ____ _   ) = 12
+        Assert Equals(len(clever_f#_mark_direct(1, 1)), 12)
+    End
+
+    It should highlight backward characters
+        normal! gg$
+        "     pOge huga Hiyo pOyo
+        " len(   _ ____ __ _____#) = 12
+        Assert Equals(len(clever_f#_mark_direct(0, 1)), 12)
+    End
+
+    It should highlight characters to which the cursor can be moved by one hop
+        normal! gg0
+        "     pOge huga Hiyo pOyo
+        " len(#      _ _      ___) = 5
+        Assert Equals(len(clever_f#_mark_direct(1, 2)), 5)
+    End
+
+    It should not highlight multibyte characters
+        normal! 2gg0
+        "     ビムかわいいよzビムx
+        " len(##            _    _) = 2
+        Assert Equals(len(clever_f#_mark_direct(1, 1)), 2)
+    End
+
+    Context with g:clever_f_smart_case
+        Before
+            let g:clever_f_smart_case = 1
+        End
+
+        After
+            let g:clever_f_smart_case = 0
+        End
+
+        It should highlight characters to which the cursor can be moved directly
+            normal! gg0
+            "     pOge huga Hiyo pOyo
+            " len(#______ _ ___  _   ) = 11
+            Assert Equals(len(clever_f#_mark_direct(1, 1)), 11)
+        End
+
+        It should highlight backward characters
+            normal! gg$
+            "     pOge huga Hiyo pOyo
+            " len(   _  ___ __  ____#) = 10
+            Assert Equals(len(clever_f#_mark_direct(0, 1)), 10)
+        End
+
+        It should highlight characters to which the cursor can be moved by one hop
+            normal! gg0
+            "     pOge huga Hiyo pOyo
+            " len(#      _ __  _  __ ) = 6
+            Assert Equals(len(clever_f#_mark_direct(1, 2)), 6)
+        End
+    End
+
+    Context with g:clever_f_ignore_case
+        Before
+            let g:clever_f_ignore_case = 1
+        End
+
+        After
+            let g:clever_f_ignore_case = 0
+        End
+
+        It should highlight characters to which the cursor can be moved directly
+            normal! gg0
+            "     pOge huga Hiyo pOyo
+            " len(#______ _  __  _   ) = 10
+            Assert Equals(len(clever_f#_mark_direct(1, 1)), 10)
+        End
+
+        It should highlight backward characters
+            normal! gg$
+            "     pOge huga Hiyo pOyo
+            " len(   _  ___ __  ____#) = 10
+            Assert Equals(len(clever_f#_mark_direct(0, 1)), 10)
+        End
+
+        It should highlight characters to which the cursor can be moved by one hop
+            normal! gg0
+            "     pOge huga Hiyo pOyo
+            " len(#      _ __  _   _ ) = 5
+            Assert Equals(len(clever_f#_mark_direct(1, 2)), 5)
+        End
+    End
+End
+
+Describe g:clever_f_mark_direct
+    Before
+        new
+        let g:clever_f_mark_direct = 1
+        call clever_f#reset()
+        highlight link CleverFDirect CleverFDefaultLabel
+        call AddLine('ビムかわいいよzビムx')
+        call AddLine('pOge huga Hiyo poyo')
+        let old_across_no_line = g:clever_f_across_no_line
+        let g:clever_f_across_no_line = 0
+    End
+
+    After
+        close!
+        let g:clever_f_mark_direct = 0
+        let g:clever_f_across_no_line = old_across_no_line
     End
 
     It should remove target highlights
@@ -1128,46 +1250,6 @@ Describe g:clever_f_mark_direct
         normal! gg$
         normal fp
         Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
-    End
-
-    Describe <Esc>
-        It should remove target highlights
-            normal! gg0
-            execute 'normal' "f\<Esc>"
-            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
-        End
-    End
-
-    Describe g:clever_f_smart_case
-        Before
-            let g:clever_f_smart_case = 1
-        End
-
-        After
-            let g:clever_f_smart_case = 0
-        End
-
-        It should make less characters highlighted
-            normal! gg0
-            normal f
-            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 10)
-        End
-    End
-
-    Describe g:clever_f_ignore_case
-        Before
-            let g:clever_f_ignore_case = 1
-        End
-
-        After
-            let g:clever_f_ignore_case = 0
-        End
-
-        It should make less characters highlighted
-            normal! gg0
-            normal f
-            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 9)
-        End
     End
 End
 " vim:foldmethod=marker

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -1114,7 +1114,7 @@ End
 
 Describe clever_f#_mark_direct()
     function! GetHighlightedPositions()
-        let cols = sort(map(getmatches(), {_, m -> m.pos1[1]}), 'n')
+        let cols = sort(map(getmatches(), 'v:val.pos1[1]'), 'n')
         let chars = []
         for c in range(1, 19)
             if len(cols) > 0 && cols[0] == c
@@ -1176,7 +1176,7 @@ Describe clever_f#_mark_direct()
         "               _    _
         call clever_f#_mark_direct(1, 1)
         let cols = [22, 29]
-        Assert Equals(sort(map(getmatches(), {_, m -> m.pos1[1]}), 'n'), cols)
+        Assert Equals(sort(map(getmatches(), 'v:val.pos1[1]'), 'n'), cols)
     End
 
     Context with g:clever_f_smart_case
@@ -1268,13 +1268,13 @@ Describe g:clever_f_mark_direct
     It should remove target highlights
         normal! gg0
         normal fh
-        Assert Equals(len(filter(getmatches(), {_, m -> m.group ==# 'CleverFDirect'})), 0)
+        Assert Equals(len(filter(getmatches(), 'v:val.group ==# "CleverFDirect"')), 0)
     End
 
     It should finish with no error
         normal! gg$
         normal fp
-        Assert Equals(len(filter(getmatches(), {_, m -> m.group ==# 'CleverFDirect'})), 0)
+        Assert Equals(len(filter(getmatches(), 'v:val.group ==# "CleverFDirect"')), 0)
     End
 End
 " vim:foldmethod=marker

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -41,6 +41,8 @@ Describe default config
         Assert Equals(g:clever_f_mark_char_color, 'CleverFDefaultLabel')
         Assert Equals(g:clever_f_repeat_last_char_inputs, ["\<CR>"])
         Assert Equals(g:clever_f_clean_labels_eagerly, 1)
+        Assert Equals(g:clever_f_mark_direct, 0)
+        Assert Equals(g:clever_f_mark_direct_color, 'CleverFDefaultLabel')
     End
 End
 
@@ -1093,4 +1095,79 @@ Describe selection=exclusive
     End
 End
 
+Describe g:clever_f_mark_direct
+    Before
+        new
+        let g:clever_f_mark_direct = 1
+        call clever_f#reset()
+        highlight link CleverFDirect CleverFDefaultLabel
+        call AddLine('pOge huga Hiyo poyo')
+        let old_across_no_line = g:clever_f_across_no_line
+        let g:clever_f_across_no_line = 0
+    End
+
+    After
+        close!
+        let g:clever_f_mark_direct = 0
+        let g:clever_f_across_no_line = old_across_no_line
+    End
+
+    It should highlight target characters automatically
+        normal! gg0
+        normal f
+        Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 11)
+    End
+
+    It should remove target highlights
+        normal! gg0
+        normal fh
+        Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
+    End
+
+    It should finish with no error
+        normal! gg$
+        normal fp
+        Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
+    End
+
+    Describe <Esc>
+        It should remove target highlights
+            normal! gg0
+            execute 'normal' "f\<Esc>"
+            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
+        End
+    End
+
+    Describe g:clever_f_smart_case
+        Before
+            let g:clever_f_smart_case = 1
+        End
+
+        After
+            let g:clever_f_smart_case = 0
+        End
+
+        It should make less characters highlighted
+            normal! gg0
+            normal f
+            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 10)
+        End
+    End
+
+    Describe g:clever_f_ignore_case
+        Before
+            let g:clever_f_ignore_case = 1
+        End
+
+        After
+            let g:clever_f_ignore_case = 0
+        End
+
+        It should make less characters highlighted
+            normal! gg0
+            normal f
+            Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 9)
+        End
+    End
+End
 " vim:foldmethod=marker

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -1113,6 +1113,21 @@ Describe selection=exclusive
 End
 
 Describe clever_f#_mark_direct()
+    function! GetHighlightedPositions()
+        let cols = sort(map(getmatches(), {_, m -> m.pos1[1]}), 'n')
+        let chars = []
+        for c in range(1, 19)
+            if len(cols) > 0 && cols[0] == c
+                let ch = '_'
+                call remove(cols, 0)
+            else
+                let ch = ' '
+            endif
+            call add(chars, ch)
+        endfor
+        return join(chars, '')
+    endfunction
+
     Before
         new
         call clever_f#reset()
@@ -1133,30 +1148,35 @@ Describe clever_f#_mark_direct()
         normal! gg0
         " #: cursor position, _: highlighted char
         "
-        "     pOge huga Hiyo pOyo
-        " len(#______ _ ____ _   ) = 12
-        Assert Equals(len(clever_f#_mark_direct(1, 1)), 12)
+        "        #Oge huga Hiyo pOyo
+        let s = ' ______ _ ____ _   '
+        call clever_f#_mark_direct(1, 1)
+        Assert Equals(GetHighlightedPositions(), s)
     End
 
     It should highlight backward characters
         normal! gg$
-        "     pOge huga Hiyo pOyo
-        " len(   _ ____ __ _____#) = 12
-        Assert Equals(len(clever_f#_mark_direct(0, 1)), 12)
+        "        pOge huga Hiyo pOy#
+        let s = '   _ ____ __ _____ '
+        call clever_f#_mark_direct(0, 1)
+        Assert Equals(GetHighlightedPositions(), s)
     End
 
     It should highlight characters to which the cursor can be moved by one hop
         normal! gg0
-        "     pOge huga Hiyo pOyo
-        " len(#      _ _      ___) = 5
-        Assert Equals(len(clever_f#_mark_direct(1, 2)), 5)
+        "        #Oge huga Hiyo pOyo
+        let s = '       _ _      ___'
+        call clever_f#_mark_direct(1, 2)
+        Assert Equals(GetHighlightedPositions(), s)
     End
 
     It should not highlight multibyte characters
         normal! 2gg0
-        "     ビムかわいいよzビムx
-        " len(##            _    _) = 2
-        Assert Equals(len(clever_f#_mark_direct(1, 1)), 2)
+        " ＃ムかわいいよzビムx
+        "               _    _
+        call clever_f#_mark_direct(1, 1)
+        let cols = [22, 29]
+        Assert Equals(sort(map(getmatches(), {_, m -> m.pos1[1]}), 'n'), cols)
     End
 
     Context with g:clever_f_smart_case
@@ -1170,23 +1190,26 @@ Describe clever_f#_mark_direct()
 
         It should highlight characters to which the cursor can be moved directly
             normal! gg0
-            "     pOge huga Hiyo pOyo
-            " len(#______ _ ___  _   ) = 11
-            Assert Equals(len(clever_f#_mark_direct(1, 1)), 11)
+            "        #Oge huga Hiyo pOyo
+            let s = ' ______ _ ___  _   '
+            call clever_f#_mark_direct(1, 1)
+            Assert Equals(GetHighlightedPositions(), s)
         End
 
         It should highlight backward characters
             normal! gg$
-            "     pOge huga Hiyo pOyo
-            " len(   _  ___ __  ____#) = 10
-            Assert Equals(len(clever_f#_mark_direct(0, 1)), 10)
+            "        pOge huga Hiyo pOy#
+            let s = '   _  ___ __  ____ '
+            call clever_f#_mark_direct(0, 1)
+            Assert Equals(GetHighlightedPositions(), s)
         End
 
         It should highlight characters to which the cursor can be moved by one hop
             normal! gg0
-            "     pOge huga Hiyo pOyo
-            " len(#      _ __  _  __ ) = 6
-            Assert Equals(len(clever_f#_mark_direct(1, 2)), 6)
+            "        #Oge huga Hiyo pOyo
+            let s = '       _ __  _  __ '
+            call clever_f#_mark_direct(1, 2)
+            Assert Equals(GetHighlightedPositions(), s)
         End
     End
 
@@ -1201,23 +1224,26 @@ Describe clever_f#_mark_direct()
 
         It should highlight characters to which the cursor can be moved directly
             normal! gg0
-            "     pOge huga Hiyo pOyo
-            " len(#______ _  __  _   ) = 10
-            Assert Equals(len(clever_f#_mark_direct(1, 1)), 10)
+            "        #Oge huga Hiyo pOyo
+            let s = ' ______ _  __  _   '
+            call clever_f#_mark_direct(1, 1)
+            Assert Equals(GetHighlightedPositions(), s)
         End
 
         It should highlight backward characters
             normal! gg$
-            "     pOge huga Hiyo pOyo
-            " len(   _  ___ __  ____#) = 10
-            Assert Equals(len(clever_f#_mark_direct(0, 1)), 10)
+            "        pOge huga Hiyo pOy#
+            let s = '   _  ___ __  ____ '
+            call clever_f#_mark_direct(0, 1)
+            Assert Equals(GetHighlightedPositions(), s)
         End
 
         It should highlight characters to which the cursor can be moved by one hop
             normal! gg0
-            "     pOge huga Hiyo pOyo
-            " len(#      _ __  _   _ ) = 5
-            Assert Equals(len(clever_f#_mark_direct(1, 2)), 5)
+            "        #Oge huga Hiyo pOyo
+            let s = '       _ __  _   _ '
+            call clever_f#_mark_direct(1, 2)
+            Assert Equals(GetHighlightedPositions(), s)
         End
     End
 End
@@ -1228,7 +1254,6 @@ Describe g:clever_f_mark_direct
         let g:clever_f_mark_direct = 1
         call clever_f#reset()
         highlight link CleverFDirect CleverFDefaultLabel
-        call AddLine('ビムかわいいよzビムx')
         call AddLine('pOge huga Hiyo poyo')
         let old_across_no_line = g:clever_f_across_no_line
         let g:clever_f_across_no_line = 0
@@ -1243,13 +1268,13 @@ Describe g:clever_f_mark_direct
     It should remove target highlights
         normal! gg0
         normal fh
-        Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
+        Assert Equals(len(filter(getmatches(), {_, m -> m.group ==# 'CleverFDirect'})), 0)
     End
 
     It should finish with no error
         normal! gg$
         normal fp
-        Assert Equals(len(filter(getmatches(), 'v:val.group==#"CleverFDirect"')), 0)
+        Assert Equals(len(filter(getmatches(), {_, m -> m.group ==# 'CleverFDirect'})), 0)
     End
 End
 " vim:foldmethod=marker


### PR DESCRIPTION
This PR adds feature to highlight characters to which the cursor can be moved directly.

demo screen cast (`fgj^fm`):

[![Screenshot from Gyazo](https://gyazo.com/0765312f8f14a851b0a671e069d134f2/raw)](https://gyazo.com/0765312f8f14a851b0a671e069d134f2)

This behavior is like [deris/vim-shot-f](https://github.com/deris/vim-shot-f) and previously mentioned in #29 . This PR introduces two variables `g:clever_f_mark_direct` and `g:clever_f_mark_direct_color`.

## TODO
- [x] fix tests
- [x] add document

**NOTE** This PR doesn't add migemo support.