### PR TITLE
make highlight link correctly for defined groups

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -16,7 +16,7 @@ let g:clever_f_repeat_last_char_inputs = get(g:, 'clever_f_repeat_last_char_inpu
 let g:clever_f_mark_direct             = get(g:, 'clever_f_mark_direct', 0)
 
 " below variable must be set before loading this script
-let g:clever_f_clean_labels_eagerly = get(g:, 'clever_f_clean_labels_eagerly', 1)
+let g:clever_f_clean_labels_eagerly    = get(g:, 'clever_f_clean_labels_eagerly', 1)
 
 " highlight labels
 augroup plugin-clever-f-highlight
@@ -29,21 +29,21 @@ if g:clever_f_mark_cursor
     if exists('g:clever_f_mark_cursor_color')
         execute 'highlight! link CleverFCursor' g:clever_f_mark_cursor_color
     else
-        execute 'highlight link CleverFCursor Cursor'
+        highlight link CleverFCursor Cursor
     endif
 endif
 if g:clever_f_mark_char
     if exists('g:clever_f_mark_char_color')
         execute 'highlight! link CleverFChar' g:clever_f_mark_char_color
     else
-        execute 'highlight link CleverFChar CleverFDefaultLabel'
+        highlight link CleverFChar CleverFDefaultLabel
     endif
 endif
 if g:clever_f_mark_direct
     if exists('g:clever_f_mark_direct_color')
         execute 'highlight! link CleverFDirect' g:clever_f_mark_direct_color
     else
-        execute 'highlight link CleverFDirect CleverFDefaultLabel'
+        highlight link CleverFDirect CleverFDefaultLabel
     endif
 endif
 

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -15,11 +15,8 @@ let g:clever_f_mark_char               = get(g:, 'clever_f_mark_char', 1)
 let g:clever_f_repeat_last_char_inputs = get(g:, 'clever_f_repeat_last_char_inputs', ["\<CR>"])
 let g:clever_f_mark_direct             = get(g:, 'clever_f_mark_direct', 0)
 
-" below variables must be set before loading this script
-let g:clever_f_mark_cursor_color       = get(g:, 'clever_f_mark_cursor_color', 'Cursor')
-let g:clever_f_mark_char_color         = get(g:, 'clever_f_mark_char_color', 'CleverFDefaultLabel')
-let g:clever_f_mark_direct_color       = get(g:, 'clever_f_mark_direct_color', 'CleverFDefaultLabel')
-let g:clever_f_clean_labels_eagerly    = get(g:, 'clever_f_clean_labels_eagerly', 1)
+" below variable must be set before loading this script
+let g:clever_f_clean_labels_eagerly = get(g:, 'clever_f_clean_labels_eagerly', 1)
 
 " highlight labels
 augroup plugin-clever-f-highlight
@@ -29,13 +26,25 @@ augroup END
 highlight default CleverFDefaultLabel ctermfg=red ctermbg=NONE cterm=bold,underline guifg=red guibg=NONE gui=bold,underline
 
 if g:clever_f_mark_cursor
-    execute 'highlight link CleverFCursor' g:clever_f_mark_cursor_color
+    if exists('g:clever_f_mark_cursor_color')
+        execute 'highlight! link CleverFCursor' g:clever_f_mark_cursor_color
+    else
+        execute 'highlight link CleverFCursor Cursor'
+    endif
 endif
 if g:clever_f_mark_char
-    execute 'highlight link CleverFChar' g:clever_f_mark_char_color
+    if exists('g:clever_f_mark_char_color')
+        execute 'highlight! link CleverFChar' g:clever_f_mark_char_color
+    else
+        execute 'highlight link CleverFChar CleverFDefaultLabel'
+    endif
 endif
 if g:clever_f_mark_direct
-    execute 'highlight link CleverFDirect' g:clever_f_mark_direct_color
+    if exists('g:clever_f_mark_direct_color')
+        execute 'highlight! link CleverFDirect' g:clever_f_mark_direct_color
+    else
+        execute 'highlight link CleverFDirect CleverFDefaultLabel'
+    endif
 endif
 
 if g:clever_f_clean_labels_eagerly


### PR DESCRIPTION
When highlight groups `CleverFCursor`, `CleverFChar`, and `CleverFDirect` are defined by colorscheme (e.g. [spring-night](https://github.com/rhysd/vim-color-spring-night) defines `CleverFChar`), `g:clever_f_mark_*_color` is ignored because `highlight link` does not overwrite them.
~~So I think it should be `highlight! link`.~~

It was not correct.
The expected behavior is:
- if `g:clever_f_mark_*_color` exists, highlight link should always be made with `highlight! link`
- else, highlight link should be made only when it has not done yet (by colorscheme) so use `highlight link`.