### PR TITLE
Reset previous_pos in finalize function to address unexpected behavior.

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -357,6 +357,7 @@ endfunction
 function! s:finalize() abort
     autocmd! plugin-clever-f-finalizer
     call s:remove_highlight()
+    let s:previous_pos = {}
     let s:moved_forward = 0
 endfunction
 


### PR DESCRIPTION
Without this call, if the cursor is moved away from the current search
result and then back to it then an additional invocation of the search
function will jump to the next result rather than starting a new search
as it should.