### PR TITLE
Fix direct-marker error when line is empty

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -122,7 +122,7 @@ function! s:mark_direct(forward, count) abort
     let line = getline('.')
     let [_, l, c, _] = getpos('.')
 
-    if (a:forward && c == len(line)) || (!a:forward && c == 1)
+    if (a:forward && c >= len(line)) || (!a:forward && c == 1)
         " there is no matching characters
         return []
     endif


### PR DESCRIPTION
## problem
When `g:clever_f_mark_direct=1` and the line that the cursor is on is empty, an error like this is thrown.
```
Error detected while processing function clever_f#find_with:
line   71:
E121: Undefined variable: direct_markers
```
Checking into the code, this problem is caused by `range()` function error(E727) in `s:mark_direct()` because the column number is larger than `len(getline('.'))` when the line is empty.