### PR TITLE
g:clever_f_mark_direct extended beyond ASCII

### DIFF
--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -157,7 +157,7 @@ function! clever_f#_mark_direct(forward, count) abort
     let char_count = {}
     let matches = []
     if a:forward 
-        let line=split(line[c:], '\zs')
+        let line = split(line[c:], '\zs')
         let i=c
     else
         let line=reverse(split(line[0:c-1], '\zs'))

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -157,8 +157,8 @@ function! clever_f#_mark_direct(forward, count) abort
     let char_count = {}
     let matches = []
     if a:forward 
-        let line = split(line[c-1 : ], '\zs')
-        let i = c + len(line[0])
+        let line = split(line[c - 1 : ], '\zs')
+        let i = c - 1 + len(line[0])
     else
         let line = reverse(split(line[0 : c-1], '\zs'))
         let i = c - len(line[0])

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -161,7 +161,7 @@ function! clever_f#_mark_direct(forward, count) abort
         let i = c - 1 + len(line[0])
         let line = line[1:] " skip char under cursor
     else
-        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, need new option to add `max(0,c-4*termcol*termlines-1000)` instead of 0 would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char off screen
+        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, new option to use `max(0,c-4*termcol*termlines-1000)` instead of `0` would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char (which would be off screen)
         let i = c - 1
     endif
     for ch in line

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -157,13 +157,13 @@ function! clever_f#_mark_direct(forward, count) abort
     let char_count = {}
     let matches = []
     if a:forward 
-        let line = split(line[c:], '\zs')
-        let i=c
+        let line = split(line[c-1 : ], '\zs')
+        let i = c + len(line[0])
     else
-        let line=reverse(split(line[0:c-1], '\zs'))
-        let i=c-len(line[0]) " skip utf8 char under cursor
-        let line=line[1:]
+        let line = reverse(split(line[0 : c-1], '\zs'))
+        let i = c - len(line[0])
     endif
+    let line = line[1:] " skip char under cursor
     for ch in line
         if !a:forward 
             let i -= len(ch)

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -157,11 +157,11 @@ function! clever_f#_mark_direct(forward, count) abort
     let char_count = {}
     let matches = []
     if a:forward 
-        let line = split(line[c - 1 : ], '\zs') " adding a limit like maxcol*maxlines just after `:` is a free gift in a very long line.
+        let line = split(line[c - 1 : ], '\zs') " adding a limit like c+4*termcol*termlines just after `:` is a free gift in a very long line, assuming all char are less than 4 bytes.
         let i = c - 1 + len(line[0])
         let line = line[1:] " skip char under cursor
     else
-        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, adding option to seek arbitrarily at c-maxcol*maxlines would help on a very long line
+        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, adding option to add `c-4*termcol*termlines-1000` instead of 0 would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char off screen
         let i = c - 1
     endif
     for ch in line

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -156,11 +156,18 @@ function! clever_f#_mark_direct(forward, count) abort
 
     let char_count = {}
     let matches = []
-    let indices = a:forward ? range(c, len(line) - 1, 1) : range(c - 2, 0, -1)
-    for i in indices
-        let ch = line[i]
-        " only matches to ASCII
-        if ch !~# '^[\x00-\x7F]$' | continue | endif
+    if a:forward 
+        let line=split(line[c:], '\zs')
+        let i=c
+    else
+        let line=reverse(split(line[0:c-1], '\zs'))
+        let i=c-len(line[0]) " skip utf8 char under cursor
+        let line=line[1:]
+    endif
+    for ch in line
+        if !a:forward 
+            let i = i - len(ch)
+        endif
         let ch_lower = tolower(ch)
 
         let char_count[ch] = get(char_count, ch, 0) + 1
@@ -175,6 +182,9 @@ function! clever_f#_mark_direct(forward, count) abort
             " because the maximum number of position is 8
             let m = matchaddpos('CleverFDirect', [[l, i + 1]])
             call add(matches, m)
+        endif
+        if a:forward 
+            let i = i + len(ch)
         endif
     endfor
     return matches

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -184,7 +184,7 @@ function! clever_f#_mark_direct(forward, count) abort
             call add(matches, m)
         endif
         if a:forward 
-            let i = i + len(ch)
+            let i += len(ch)
         endif
     endfor
     return matches

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -161,7 +161,7 @@ function! clever_f#_mark_direct(forward, count) abort
         let i = c - 1 + len(line[0])
         let line = line[1:] " skip char under cursor
     else
-        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, adding option to add `c-4*termcol*termlines-1000` instead of 0 would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char off screen
+        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, adding option to add `max(0,c-4*termcol*termlines-1000)` instead of 0 would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char off screen
         let i = c - 1
     endif
     for ch in line

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -157,13 +157,13 @@ function! clever_f#_mark_direct(forward, count) abort
     let char_count = {}
     let matches = []
     if a:forward 
-        let line = split(line[c - 1 : ], '\zs')
+        let line = split(line[c - 1 : ], '\zs') " adding a limit like maxcol*maxlines just after `:` is a free gift in a very long line.
         let i = c - 1 + len(line[0])
+        let line = line[1:] " skip char under cursor
     else
-        let line = reverse(split(line[0 : c-1], '\zs'))
-        let i = c - len(line[0])
+        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, adding option to seek arbitrarily at c-maxcol*maxlines would help on a very long line
+        let i = c - 1
     endif
-    let line = line[1:] " skip char under cursor
     for ch in line
         if !a:forward 
             let i -= len(ch)

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -161,7 +161,7 @@ function! clever_f#_mark_direct(forward, count) abort
         let i = c - 1 + len(line[0])
         let line = line[1:] " skip char under cursor
     else
-        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, adding option to add `max(0,c-4*termcol*termlines-1000)` instead of 0 would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char off screen
+        let line = reverse(split(line[0 : c - 2], '\zs')) " split() is slow on very long lines, need new option to add `max(0,c-4*termcol*termlines-1000)` instead of 0 would help on a very long line, with the drawback of seeking at an arbitrarily byte possibly in the middle of a multibyte char off screen
         let i = c - 1
     endif
     for ch in line

--- a/autoload/clever_f.vim
+++ b/autoload/clever_f.vim
@@ -166,7 +166,7 @@ function! clever_f#_mark_direct(forward, count) abort
     endif
     for ch in line
         if !a:forward 
-            let i = i - len(ch)
+            let i -= len(ch)
         endif
         let ch_lower = tolower(ch)
 

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -1278,7 +1278,7 @@ Describe clever_f#_mark_direct()
         Assert Equals(GetHighlightedPositions(), s)
     End
 
-    It should correctly highlight first of each multibyte characters
+    It should highlight multibyte characters to which the cursor can be moved directly
         normal! 2gg0
         "        ＃ムかわいいよzビムx
         let s = 'ビ＃＃＃＃い＃_＃ム_'

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -1278,12 +1278,12 @@ Describe clever_f#_mark_direct()
         Assert Equals(GetHighlightedPositions(), s)
     End
 
-    It should not highlight multibyte characters
+    It should correctly highlight first of each multibyte characters
         normal! 2gg0
-        " ＃ムかわいいよzビムx
-        "               _    _
+        "        ＃ムかわいいよzビムx
+        let s = 'ビ＃＃＃＃い＃_＃ム_'
         call clever_f#_mark_direct(1, 1)
-        let cols = [22, 29]
+        let cols = filter(range(0,len(s)),'s[v:val]=="_"||s[v:val]=="＃"[0]')
         Assert Equals(sort(map(getmatches(), 'v:val.pos1[1]'), 'n'), cols)
     End
 

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -1283,7 +1283,16 @@ Describe clever_f#_mark_direct()
         "        ＃ムかわいいよzビムx
         let s = 'ビ＃＃＃＃い＃_＃ム_'
         call clever_f#_mark_direct(1, 1)
-        let cols = filter(range(0,len(s)),'s[v:val]=="_"||s[v:val]=="＃"[0]')
+        let cols = filter(range(1,len(s)),'s[v:val-1]=="_"||s[v:val-1]=="＃"[0]')
+        Assert Equals(sort(map(getmatches(), 'v:val.pos1[1]'), 'n'), cols)
+    End
+
+    It should highlight multibyte characters to which the cursor can be moved backwards
+        normal! 2gg$h
+        "        ビムかわいいよzビ＃x
+        let s = 'ビ＃＃＃い＃＃_＃ムx'
+        call clever_f#_mark_direct(0, 1)
+        let cols = filter(range(1,len(s)),'s[v:val-1]=="_"||s[v:val-1]=="＃"[0]')
         Assert Equals(sort(map(getmatches(), 'v:val.pos1[1]'), 'n'), cols)
     End
 


### PR DESCRIPTION
`ch`, instead of just containing a byte (that is ignored when non-ASCII, e.g., coding utf8 or other encoding), now contains a possibly multibyte char. `line` is changed to contain the list of these groupped non-ASCII chars. Tested on utf8.